### PR TITLE
Add Binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Intro. to Deep Learning on HAL
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/khanx169/hal_tutorial/master)
+
 This tutorial covers the basics of Deep Learning with Convolutional Neural Nets. The tutorial is broken into three notebooks. The topics covered in each notebook are:
 
 1. **Intro.ipynb**: 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,7 @@
+numpy~=1.17
+matplotlib~=3.1
+scipy~=1.3
+tensorflow~=1.14
+Keras~=2.2
+Pillow~=6.1
+opencv-python~=4.1


### PR DESCRIPTION
I know this tutorial is meant for HAL, but it would be great to have the tutorial also be web interactive by [Binderizing the repo](https://mybinder.org/).

Given the imports in the notebooks, this adds a `requirements.txt` that Binder looks for in the `binder` directory exists and then builds an image with those. For a demo of what this looks like you can click on this badge which will launch the Binder of my fork:
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/hal_tutorial/feature/add-Binder)